### PR TITLE
Remove version from epaper display

### DIFF
--- a/lib/config/config.h
+++ b/lib/config/config.h
@@ -20,7 +20,7 @@
 #define HAS_BME680
 // #define HAS_BATTERY
 #define OTA_UPDATE_ENABLED
-#define DISPLAY_NODE_VERSIONS
+// #define DISPLAY_NODE_VERSIONS
 // #define DISPLAY_TIME
 #endif
 

--- a/lib/views/epd_view_2.cpp
+++ b/lib/views/epd_view_2.cpp
@@ -305,7 +305,6 @@ uint EPDView2::displayNodes(const RenderContext& ctx) {
       JsonObject nodeData = node.value().as<JsonObject>();
       displayNodeHeader(node, nodeData, ctx, column, row, row_offset);
       displayNodeMeasurements(nodeData, ctx, column, row, row_offset);
-      // displayBatteryLevel(nodeData, ctx.node_count, column, row, row_offset);
       displayBadStatuses(nodeData, ctx.node_count, column, row, row_offset);
       displayStaleState(nodeData, ctx.node_count, column, row, row_offset);
       displayNodeVersion(nodeData, ctx.node_count, column, row, row_offset);


### PR DESCRIPTION
No longer display firmware versions on epaper display since we can now see this on the dashboard instead.